### PR TITLE
fftools/Makefile: remove reference to libavresample

### DIFF
--- a/fftools/Makefile
+++ b/fftools/Makefile
@@ -5,7 +5,7 @@ AVPROGS-$(CONFIG_FFPROBE)  += ffprobe
 AVPROGS     := $(AVPROGS-yes:%=%$(PROGSSUF)$(EXESUF))
 PROGS       += $(AVPROGS)
 MYTHPROGS   = $(addprefix myth, ${PROGS})
-MYTHFFLIBS  = -lmythavfilter -lmythavformat -lmythavcodec -lmythavresample \
+MYTHFFLIBS  = -lmythavfilter -lmythavformat -lmythavcodec \
 -lmythpostproc -lmythswresample -lmythswscale
 
 AVBASENAMES  = ffmpeg ffplay ffprobe


### PR DESCRIPTION
FFmpeg removed it since it duplicated libswresample.

I missed this for PR #6 .