### PR TITLE
Sync release/5.1 with MythTV

### DIFF
--- a/compat/w32dlfcn.h
+++ b/compat/w32dlfcn.h
@@ -35,7 +35,7 @@ static inline wchar_t *get_module_filename(HMODULE module)
 
     do {
         path_size = path_size ? FFMIN(2 * path_size, INT16_MAX + 1) : MAX_PATH;
-        new_path = av_realloc_array(path, path_size, sizeof *path);
+        new_path = (wchar_t *)av_realloc_array(path, path_size, sizeof *path);
         if (!new_path) {
             av_free(path);
             return NULL;

--- a/configure
+++ b/configure
@@ -5571,7 +5571,8 @@ case $target_os in
         SLIBPREF="libmyth"
         SLIBSUF=".dll"
         SLIBNAME_WITH_VERSION='$(SLIBPREF)$(FULLNAME)-$(LIBVERSION)$(SLIBSUF)'
-        SLIBNAME_WITH_MAJOR='$(SLIBPREF)$(FULLNAME)-$(LIBMAJOR)$(SLIBSUF)'
+        #SLIBNAME_WITH_MAJOR='$(SLIBPREF)$(FULLNAME)-$(LIBMAJOR)$(SLIBSUF)'
+        SLIBNAME_WITH_MAJOR='$(SLIBPREF)$(FULLNAME)$(SLIBSUF)'
         if test_cmd lib.exe -list; then
             SLIB_EXTRA_CMD=-'lib.exe -nologo -machine:$(LIBTARGET) -def:$$(@:$(SLIBSUF)=.def) -out:$(SUBDIR)$(SLIBNAME:$(SLIBSUF)=.lib)'
             if enabled x86_64; then

--- a/configure
+++ b/configure
@@ -5582,7 +5582,7 @@ case $target_os in
         fi
         SLIB_INSTALL_NAME='$(SLIBNAME_WITH_MAJOR)'
         SLIB_INSTALL_LINKS=
-        SLIB_INSTALL_EXTRA_SHLIB='$(SLIBNAME:$(SLIBSUF)=.lib)'
+        #SLIB_INSTALL_EXTRA_SHLIB='$(SLIBNAME:$(SLIBSUF)=.lib)'
         SLIB_INSTALL_EXTRA_LIB='lib$(SLIBNAME:$(SLIBSUF)=.dll.a) $(SLIBNAME_WITH_MAJOR:$(SLIBSUF)=.def)'
         SLIB_CREATE_DEF_CMD='EXTERN_PREFIX="$(EXTERN_PREFIX)" AR="$(AR_CMD)" NM="$(NM_CMD)" $(SRC_PATH)/compat/windows/makedef $(SUBDIR)lib$(NAME).ver $(OBJS) > $$(@:$(SLIBSUF)=.def)'
         SHFLAGS='-shared -Wl,--out-implib,$(SUBDIR)lib$(SLIBNAME:$(SLIBSUF)=.dll.a) -Wl,--disable-auto-image-base $$(@:$(SLIBSUF)=.def)'

--- a/ffbuild/library.mak
+++ b/ffbuild/library.mak
@@ -11,8 +11,8 @@ INCINSTDIR := $(INCDIR)/lib$(NAME)
 
 INSTHEADERS := $(INSTHEADERS) $(HEADERS:%=$(SUBDIR)%)
 
-all-$(CONFIG_STATIC): $(SUBDIR)$(LIBNAME)  $(SUBDIR)lib$(FULLNAME).pc
-all-$(CONFIG_SHARED): $(SUBDIR)$(SLIBNAME) $(SUBDIR)lib$(FULLNAME).pc
+all-$(CONFIG_STATIC): $(SUBDIR)$(LIBNAME)  $(SUBDIR)libmyth$(FULLNAME).pc
+all-$(CONFIG_SHARED): $(SUBDIR)$(SLIBNAME) $(SUBDIR)libmyth$(FULLNAME).pc
 
 LIBOBJS := $(OBJS) $(SHLIBOBJS) $(STLIBOBJS) $(SUBDIR)%.h.o $(TESTOBJS)
 $(LIBOBJS) $(LIBOBJS:.o=.s) $(LIBOBJS:.o=.i):   CPPFLAGS += -DHAVE_AV_CONFIG_H
@@ -40,6 +40,7 @@ $(SUBDIR)$(LIBNAME): $(OBJS) $(STLIBOBJS)
 
 #install-headers: install-lib$(NAME)-headers install-lib$(NAME)-pkgconfig
 install-headers: install-lib$(NAME)-headers
+install-pkgconfig: install-libmyth$(NAME)-pkgconfig
 
 install-libs-$(CONFIG_STATIC): install-lib$(NAME)-static
 install-libs-$(CONFIG_SHARED): install-lib$(NAME)-shared
@@ -56,7 +57,7 @@ $(TESTPROGS) $(TOOLS): %$(EXESUF): %.o
 $(SUBDIR)lib$(NAME).version: $(SUBDIR)version.h $(SUBDIR)version_major.h | $(SUBDIR)
 	$$(M) $$(SRC_PATH)/ffbuild/libversion.sh $(NAME) $$^ > $$@
 
-$(SUBDIR)lib$(FULLNAME).pc: $(SUBDIR)version.h ffbuild/config.sh | $(SUBDIR)
+$(SUBDIR)libmyth$(FULLNAME).pc: $(SUBDIR)version.h ffbuild/config.sh | $(SUBDIR)
 	$$(M) $$(SRC_PATH)/ffbuild/pkgconfig_generate.sh $(NAME) "$(DESC)"
 
 $(SUBDIR)lib$(NAME).ver: $(SUBDIR)lib$(NAME).v $(OBJS)
@@ -96,7 +97,7 @@ install-lib$(NAME)-headers: $(addprefix $(SUBDIR),$(HEADERS) $(BUILT_HEADERS))
 	$(Q)mkdir -p "$(INCINSTDIR)"
 	$$(INSTALL) -m 644 $$^ "$(INCINSTDIR)"
 
-install-lib$(NAME)-pkgconfig: $(SUBDIR)lib$(FULLNAME).pc
+install-libmyth$(NAME)-pkgconfig: $(SUBDIR)libmyth$(FULLNAME).pc
 	$(Q)mkdir -p "$(PKGCONFIGDIR)"
 	$$(INSTALL) -m 644 $$^ "$(PKGCONFIGDIR)"
 
@@ -113,7 +114,7 @@ uninstall-headers::
 	-rmdir "$(INCINSTDIR)"
 
 uninstall-pkgconfig::
-	$(RM) "$(PKGCONFIGDIR)/lib$(FULLNAME).pc"
+	$(RM) "$(PKGCONFIGDIR)/libmyth$(FULLNAME).pc"
 endef
 
 $(eval $(RULES))

--- a/ffbuild/pkgconfig_generate.sh
+++ b/ffbuild/pkgconfig_generate.sh
@@ -10,14 +10,14 @@ fi
 
 shortname=$1
 name=lib${shortname}
-fullname=${name}${build_suffix}
+fullname=libmyth${shortname}${build_suffix}
 comment=$2
 libs=$(eval echo \$extralibs_${shortname})
 deps=$(eval echo \$${shortname}_deps)
 
 for dep in $deps; do
     depname=lib${dep}
-    fulldepname=${depname}${build_suffix}
+    fulldepname=libmyth${dep}${build_suffix}
     . ${depname}/${depname}.version
     depversion=$(eval echo \$${depname}_VERSION)
     requires="$requires ${fulldepname} >= ${depversion}, "

--- a/fftools/Makefile
+++ b/fftools/Makefile
@@ -36,14 +36,14 @@ fftools/ffprobe.o fftools/cmdutils.o: libavutil/ffversion.h | fftools
 OUTDIRS += fftools
 
 # ${MYTHPROGS}:
-mythffmpeg:	ffmpeg_g
-	cp ffmpeg_g mythffmpeg
+mythffmpeg$(EXESUF): ffmpeg_g$(EXESUF)
+	cp ffmpeg_g$(EXESUF) mythffmpeg$(EXESUF)
 
-mythffprobe: ffprobe_g
-	cp ffprobe_g mythffprobe
+mythffprobe$(EXESUF): ffprobe_g$(EXESUF)
+	cp ffprobe_g$(EXESUF) mythffprobe$(EXESUF)
 
-mythffplay: ffplay_g
-	cp ffplay_g mythffplay
+mythffplay$(EXESUF): ffplay_g$(EXESUF)
+	cp ffplay_g$(EXESUF) mythffplay$(EXESUF)
 
 ifdef AVPROGS
 install: install-mythprogs

--- a/fftools/Makefile
+++ b/fftools/Makefile
@@ -36,16 +36,13 @@ fftools/ffprobe.o fftools/cmdutils.o: libavutil/ffversion.h | fftools
 OUTDIRS += fftools
 
 # ${MYTHPROGS}:
-mythffmpeg:
+mythffmpeg:	ffmpeg_g
 	cp ffmpeg_g mythffmpeg
 
-mythffprobe:
+mythffprobe: ffprobe_g
 	cp ffprobe_g mythffprobe
 
-mythffserver:
-	cp ffserver_g mythffserver
-
-mythffplay:
+mythffplay: ffplay_g
 	cp ffplay_g mythffplay
 
 ifdef AVPROGS

--- a/libavcodec/x86/mathops.h
+++ b/libavcodec/x86/mathops.h
@@ -35,12 +35,20 @@
 static av_always_inline av_const int MULL(int a, int b, unsigned shift)
 {
     int rt, dummy;
+    if (__builtin_constant_p(shift))
     __asm__ (
         "imull %3               \n\t"
         "shrdl %4, %%edx, %%eax \n\t"
         :"=a"(rt), "=d"(dummy)
-        :"a"(a), "rm"(b), "ci"((uint8_t)shift)
+        :"a"(a), "rm"(b), "i"(shift & 0x1F)
     );
+    else
+        __asm__ (
+            "imull %3               \n\t"
+            "shrdl %4, %%edx, %%eax \n\t"
+            :"=a"(rt), "=d"(dummy)
+            :"a"(a), "rm"(b), "c"((uint8_t)shift)
+        );
     return rt;
 }
 
@@ -113,19 +121,31 @@ __asm__ volatile(\
 // avoid +32 for shift optimization (gcc should do that ...)
 #define NEG_SSR32 NEG_SSR32
 static inline  int32_t NEG_SSR32( int32_t a, int8_t s){
+    if (__builtin_constant_p(s))
     __asm__ ("sarl %1, %0\n\t"
          : "+r" (a)
-         : "ic" ((uint8_t)(-s))
+         : "i" (-s & 0x1F)
     );
+    else
+        __asm__ ("sarl %1, %0\n\t"
+               : "+r" (a)
+               : "c" ((uint8_t)(-s))
+        );
     return a;
 }
 
 #define NEG_USR32 NEG_USR32
 static inline uint32_t NEG_USR32(uint32_t a, int8_t s){
+    if (__builtin_constant_p(s))
     __asm__ ("shrl %1, %0\n\t"
          : "+r" (a)
-         : "ic" ((uint8_t)(-s))
+         : "i" (-s & 0x1F)
     );
+    else
+        __asm__ ("shrl %1, %0\n\t"
+               : "+r" (a)
+               : "c" ((uint8_t)(-s))
+        );
     return a;
 }
 

--- a/libavformat/libavformat.v
+++ b/libavformat/libavformat.v
@@ -2,11 +2,8 @@ LIBAVFORMAT_MAJOR {
     global:
         av*;
         ffurl_read;
-        ffurl_read_complete;
         ffurl_seek;
         ffurl_size;
-        ffurl_protocol_next;
-        ffurl_open;
         ffurl_open_whitelist;
         ffurl_close;
         ffurl_write;

--- a/libavformat/mpegts-mythtv.c
+++ b/libavformat/mpegts-mythtv.c
@@ -2981,7 +2981,7 @@ static void pmt_cb(MpegTSFilter *filter, const uint8_t *section, int section_len
      * create new ones, and notify any listener.
      */
     equal_streams = pmt_equal_streams(ts, items, last_item);
-    if (0 && (equal_streams != last_item || ts->pid_cnt != last_item))
+    if (equal_streams != last_item || ts->pid_cnt != last_item)
     {
         AVFormatContext *avctx = ts->stream;
 


### PR DESCRIPTION
Comparing the files with mythtv/external/FFmpeg shows they are identical now.  Git complains:
`warning: in the working copy of 'mythtv/external/FFmpeg/tests/ref/fate/wavpack-cuesheet-tags', CRLF will be replaced by LF the next time Git touches it`
That is probably due to different settings for the git repositories.

master appears to be missing the commits from July 2023 onwards, but I am not planning on using it for the next merge.
https://github.com/MythTV/FFmpeg/commits/master/
https://github.com/MythTV/mythtv/commits/master/mythtv/external/FFmpeg